### PR TITLE
Moved initial analysis to an AnalysisCompletionEvent and BackgroundTaskThread

### DIFF
--- a/ethersplay/evm.py
+++ b/ethersplay/evm.py
@@ -383,11 +383,6 @@ class EVM(Architecture):
     def perform_assemble(self, code, addr):
         return None
 
-class InitialAnalysisCallback(AnalysisCompletionEvent):
-    def __init__(self, view, callback):
-        AnalysisCompletionEvent.__init__(self, view, callback)
-        self.analyzed = False
-
 class InitialAnalysisTask(BackgroundTaskThread):
     def __init__(self, bv):
         BackgroundTaskThread.__init__(self, "Initial Analysis", True)
@@ -490,7 +485,7 @@ class EVMView(BinaryView):
                                   (SegmentFlag.SegmentReadable |
                                    SegmentFlag.SegmentExecutable))
 
-            evt = InitialAnalysisCallback(self, analyze)
+            self.add_analysis_completion_event(analyze)
 
             return True
         except Exception as e:

--- a/ethersplay/evm.py
+++ b/ethersplay/evm.py
@@ -397,11 +397,6 @@ class InitialAnalysisTask(BackgroundTaskThread):
         run_initial_analysis(self.bv)
 
 def analyze(completion_event):
-    if completion_event.analyzed:
-        return
-
-    completion_event.analyzed = True
-
     set_worker_thread_count(4)
 
     iat = InitialAnalysisTask(completion_event.view)


### PR DESCRIPTION
The method of spawning a thread to wait until the `BinaryView` created a basic block was pretty janky, so I fixed it up by using an `AnalysisCompletionEvent` and `BackgroundTaskThread` that will run automatically as soon as the `BinaryView` creates the first function and finishes its analysis. Based on the test.bytecode I had lying around, the behavior is identical.