### PR TITLE
Refactor coverage visualizer

### DIFF
--- a/ethersplay/coverage.py
+++ b/ethersplay/coverage.py
@@ -31,7 +31,7 @@ class GraphColorer(object):
 
 
 def function_coverage_start(view):
-    visited = get_open_filename_input('Visited file', "visited.txt")
+    visited = get_open_filename_input('visited.txt or *.trace')
     colorer = GraphColorer(view)
     colorer.color(visited)
 

--- a/ethersplay/coverage.py
+++ b/ethersplay/coverage.py
@@ -4,20 +4,23 @@ from binaryninja import log
 
 blue = HighlightStandardColor.BlueHighlightColor
 
-class Coverage(object):
+class GraphColorer(object):
 
-    def __init__(self, view, visited):
+    def __init__(self, view):
         self.bb_seen = []
         self.view = view
-        self.color_visited(visited)
 
-    def color_visited(self, visited):
+    def color(self, visited):
         with open(visited,'r') as f:
             for line in f:
                 index = line.find(':') + 1
-                line = line[index:]
-                log.log(1, line)
-                self.color_at(int(line, 16))
+                addr = line[index:].split()[0]
+                log.log(1, addr)
+                try:
+                    self.color_at(int(addr, 16))
+                except ValueError:
+                    # if thrown by int()
+                    pass
 
     def color_at(self, addr):
         bbs = self.view.get_basic_blocks_at(addr)
@@ -29,5 +32,6 @@ class Coverage(object):
 
 def function_coverage_start(view):
     visited = get_open_filename_input('Visited file', "visited.txt")
-    Coverage(view, visited)
+    colorer = GraphColorer(view)
+    colorer.color(visited)
 


### PR DESCRIPTION
This PR refactors and allows ethersplay to visualize Manticore's per-state trace files (https://github.com/trailofbits/manticore/pull/817)

- Refactor the code to remove side effects from the Coverage object ctor
- Renames the Coverage object, and color_visited method
- Make coloring more robust when parsing the trace file (this is specifically needed because Manticore emits some divider lines between transaction traces)
- Removes the restriction for only 'visited.txt'