### PR TITLE
Change known hashes from comments to symbols

### DIFF
--- a/ethersplay/print_known_hashes.py
+++ b/ethersplay/print_known_hashes.py
@@ -1,5 +1,5 @@
 from known_hashes import knownHashes
-from binaryninja import Symbol, SymbolType, IntegerDisplayType, log_info
+from binaryninja import Symbol, SymbolType, IntegerDisplayType
 
 
 class HashMatcher(object):

--- a/ethersplay/print_known_hashes.py
+++ b/ethersplay/print_known_hashes.py
@@ -1,4 +1,6 @@
 from known_hashes import knownHashes
+from binaryninja import Symbol, SymbolType, IntegerDisplayType, log_info
+
 
 class HashMatcher(object):
 
@@ -12,10 +14,24 @@ class HashMatcher(object):
         for ins in bb.__iter__():
             details, size = ins
             if str(details[0]).startswith('PUSH'):
-                val = str(details[1])
-                if val in knownHashes:
-                    txt = knownHashes[val]
-                    self.func.set_comment(addr, txt)
+                operand = details[1]
+                op_text = operand.text
+                op_value = operand.value
+                if op_text in knownHashes:
+                    txt = knownHashes[op_text]
+                    self.func.view.define_user_symbol(
+                        Symbol(
+                            SymbolType.ImportedFunctionSymbol,
+                            op_value,
+                            '{} -> {}'.format(op_text, txt)
+                        )
+                    )
+                    self.func.set_int_display_type(
+                        addr,
+                        op_value,
+                        0,
+                        IntegerDisplayType.PointerDisplayType
+                    )
                     self.hashes_found += 1
             addr += size
 


### PR DESCRIPTION
Ethersplay currently sets a comment on or above the line that a function hash is pushed onto the stack. This is more aesthetically pleasing to me, because it both guarantees that the function is on the same line as the hash, but also because it colors the hash and function prototype orange.

![screen shot 2018-03-20 at 1 43 36 pm](https://user-images.githubusercontent.com/5834130/37681733-bb3d0c28-2c44-11e8-88df-78bcf8ff78ee.png)
