### PR TITLE
Avoid creating a _fallback function out of bounds

### DIFF
--- a/ethersplay/analysis.py
+++ b/ethersplay/analysis.py
@@ -119,9 +119,11 @@ def analyze_jumps(view, func):
             if current_bb == dispatcher.basic_blocks[0]:
                 true = dispatcher[il.true]
                 if true.operation == MediumLevelILOperation.MLIL_JUMP_TO:
-                    dispatch_functions.append(
-                        (true.dest.constant+1, "_fallback")
-                    )
+                    # Avoid trying to create a fallback if there is an invalid jump
+                    if true.dest.constant+1 < len(func.view):
+                        dispatch_functions.append(
+                            (true.dest.constant+1, "_fallback")
+                        )
 
             visitor = EVMVisitor(lookup=il_bb_lookup)
             visit_result = visitor.visit(il)


### PR DESCRIPTION
Some older contracts (such as ones that forward calls) will not have
a normal dispatcher form. In some of these cases, jumps were being
picked up as the fallback function, when usually they are just invalid
jumps (which have been replaced with jumps to the special invalid basic
block). This would cause ethersplay to try create and explore a function
outside of the range of the binary view, freezing binaryninja and
causing endless callbacks.

This commit adds a check to makes sure ethersplay does not try to make a
fallback function outside of the binary view. However It does not stop it
from making an erroneous one if there is a non-invalid jumpi in the
first basic block, better heuristics could be employed to stop that.

Example contract this fixes ethersplay for:
[freeze.zip](https://github.com/trailofbits/ethersplay/files/2059893/freeze.zip)
