### PR TITLE
Fix dispatcher not identifying functions on Binary Ninja Version 1.1.1216

### DIFF
--- a/ethersplay/analysis.py
+++ b/ethersplay/analysis.py
@@ -97,7 +97,8 @@ def analyze_jumps(view, func):
 
     # We'll reference these when determining if we need to create a function
     mlil_jumps = (
-        MediumLevelILOperation.MLIL_JUMP_TO, MediumLevelILOperation.MLIL_JUMP
+        MediumLevelILOperation.MLIL_JUMP_TO, MediumLevelILOperation.MLIL_JUMP,
+        MediumLevelILOperation.MLIL_TAILCALL_UNTYPED
     )
 
     dispatcher = func.medium_level_il


### PR DESCRIPTION
In binja 1.1.1216, MLIL was changed to emit tail jumps for the kind of jumps ethersplay is creating for jumps to public functions. (They don't seem to actually be visible on the MLIL view, but they the `analyze_jumps` is picking them up.

For example the target IL for one contract was `tailcall(0x51, stack = &var_20)` and the operation on it `MediumLevelILOperation.MLIL_TAILCALL_UNTYPED`.

As a fix to continue using this path anyway, I added `MediumLevelILOperation.MLIL_TAILCALL_UNTYPED` to the `mlil_jumps` array, so that the target would be added as a dispatch_function.

With this patch, it seems to work as before on version 1.1.1216

I'm not sure if there is a case where you would not want `MediumLevelILOperation.MLIL_TAILCALL_UNTYPED` as a valid jump target.

Also not sure if that operation was just added, or if it existed before. Could add a version check if it is an issue and you want to support older binja versions.