### PR TITLE
Fix #34

### DIFF
--- a/ethersplay/stack_value_analysis.py
+++ b/ethersplay/stack_value_analysis.py
@@ -795,6 +795,8 @@ class StackValueAnalysis(object):
         # If true, the following value are correct
         # If false, it means that it was a None
         def filter_vals(vals):
+            if vals is None:
+                return []
             if None in vals:
                 return [False, 0]
             return [True] + [float(x) for x in vals]


### PR DESCRIPTION
`filter_vals` wasn't handling `TOP`, causing the list comprehension in `explore` to fail when the stack was empty.