### PR TITLE
Disable linear sweep for EVMView

### DIFF
--- a/ethersplay/evm.py
+++ b/ethersplay/evm.py
@@ -414,6 +414,12 @@ class EVMView(BinaryView):
         dynamicJumpCallbackNotification = DynamicJumpCallback()
         self.register_notification(dynamicJumpCallbackNotification)
 
+        # disable linear sweep
+        self.store_metadata(
+            "ephemeral",
+            {"binaryninja.analysis.autorunLinearSweep": False}
+        )
+
         return True
 
     @staticmethod


### PR DESCRIPTION
Linear sweep is now automatic on the dev channel. This disables linear sweep for EVMView so it doesn't create a bunch of random functions.